### PR TITLE
Adding glob support

### DIFF
--- a/bin/inkdoc
+++ b/bin/inkdoc
@@ -5,6 +5,7 @@
 
 
 var fs     = require('fs'),
+    glob   = require('glob'),
     inkdoc = require('../lib/index');
 
 
@@ -81,14 +82,15 @@ lookFor(currentDir, '.inkdocrc', function(err, found) {
     //console.log('CONFIG:');
     //console.log(cfg);
 
-    var i, f = cfg.sourceFiles.length;
+    var i, globFiles = [], f = cfg.sourceFiles.length;
     if (cfg.sourceDir) {
         for (i = 0; i < f; ++i) {
-            cfg.sourceFiles[i] = [cfg.sourceDir, cfg.sourceFiles[i]].join('/');
+            globFiles.push(glob.sync(cfg.sourceFiles[i], {cwd: cfg.sourceDir}));
         }
+        cfg.sourceFiles = globFiles.join(',').split(',');
     }
 
-    //console.log(cfg.files);
+    //console.log(cfg.sourceFiles);
 
     console.log('parsing source files into metadata...');
     inkdoc.parseComments(cfg, function(err, root) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "esprima":    ">= 1.0.3",
     "fs-extra":   ">= 0.7.1",
     "handlebars": ">= 1.0.12",
-    "marked":     ">= 0.2.9"
+    "marked":     ">= 0.2.9",
+    "glob":       ">= 3.2.8"
   },
   "bin": {
     "inkdoc": "bin/inkdoc"


### PR DESCRIPTION
You can now setup a glob pattern in your .inkdocrc sourceFiles
